### PR TITLE
Add rapidjson to Mac OS install description

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ packages using Homebrew ([http://brew.sh/](http://brew.sh/)):
         ghc \
         cabal-install \
         boost \
+        rapidjson \
         boost-python
 
 (boost-python is optional and only needed for Python support.)


### PR DESCRIPTION
Fix compilation on Mac OS 10.10 by adding rapidjson to required packages.
